### PR TITLE
Fix rtol

### DIFF
--- a/pymc3/tests/test_tuning.py
+++ b/pymc3/tests/test_tuning.py
@@ -24,10 +24,11 @@ def test_mle_jacobian():
     with model:
         map_estimate = find_MAP(model=model)
 
-    np.testing.assert_allclose(map_estimate["mu_i"], truth)
+    rtol = 1E-5  # this rtol should work on both floatX precisions
+    np.testing.assert_allclose(map_estimate["mu_i"], truth, rtol=rtol)
 
     start, model, _ = models.simple_normal(bounded_prior=True)
     with model:
         map_estimate = find_MAP(model=model)
 
-    np.testing.assert_allclose(map_estimate["mu_i"], truth)
+    np.testing.assert_allclose(map_estimate["mu_i"], truth, rtol=rtol)


### PR DESCRIPTION
This test was stochastically failing on float32 due to precision, so I reduced the stringency somewhat.